### PR TITLE
removing unused imports from Navbar.js

### DIFF
--- a/item-catalog/src/components/NavBar/NavBar.js
+++ b/item-catalog/src/components/NavBar/NavBar.js
@@ -1,8 +1,7 @@
 import {React} from "react";
 import { useAuth } from "../context/user";
 import { useLocation, useNavigate, Link } from "react-router-dom";
-import { AppBar, IconButton, Tooltip, Box, Button } from "@mui/material";
-import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import { AppBar, Box, Button } from "@mui/material";
 import Settings from "./Settings";
 import "bootstrap/dist/css/bootstrap.min.css"
 

--- a/item-catalog/src/components/NavBar/NavBar.js
+++ b/item-catalog/src/components/NavBar/NavBar.js
@@ -15,6 +15,7 @@ const AppNav = () => {
 
     const signOut = () => {
         auth.logout()
+        navigate("/login", {replace: true})
     }
 
     const goToProfile = () => {

--- a/item-catalog/src/components/context/user.js
+++ b/item-catalog/src/components/context/user.js
@@ -6,7 +6,6 @@ const AuthContext = createContext(null);
 export const AuthProvider = ({children}) => {
   
     const [user, setUser] = useState(sessionStorage.getItem("signedInUser"));
-    const navigate = useNavigate()
 
     const login = (user) => {
         sessionStorage.setItem('signedInUser', user)
@@ -16,7 +15,6 @@ export const AuthProvider = ({children}) => {
     const logout = () => {
         setUser(null)
         sessionStorage.clear()
-        navigate("/login", {replace: true})
     }
 
     return (<>


### PR DESCRIPTION
Navigate in navbar component instead of logout function in user context so profile and dashboard routes actually removed from history stack